### PR TITLE
Changed order of variables passed to imageapi_image_scale

### DIFF
--- a/image_process.inc
+++ b/image_process.inc
@@ -50,7 +50,7 @@ class ImageProcessor {
     }
 
     if (!empty($height) || !empty($width)) {
-      $returnValue = imageapi_image_scale($image, $height, $width);
+      $returnValue = imageapi_image_scale($image, $width, $height);
     }
 
     if (!$returnValue) {


### PR DESCRIPTION
Variables are now in the order expected by imageapi_image_scale - see http://drupalcontrib.org/api/drupal/contributions!imageapi!imageapi.module/function/imageapi_image_scale/6
