### PR TITLE
Create derivatives prior to object ingestion

### DIFF
--- a/includes/image.process.inc
+++ b/includes/image.process.inc
@@ -12,26 +12,32 @@
  *   tuque FedoraObject
  * @return string 
  */
-function islandora_basic_image_create_all_derivatives($object) {
+function islandora_basic_image_create_all_derivatives($files, $object) {
   module_load_include('inc', 'islandora', 'includes/mime.detect');
   module_load_include('inc', 'islandora_basic_image', 'includes/image_process');
-  $mime_class = new MimeDetect();
-  if (!isset($object['OBJ'])) {
+  if (!isset($files['OBJ'])) {
     drupal_set_message(t('Could not create image derivatives for %s.  No image file was uploaded.', array('%s' => $object->id)),'error');
     return "";
   }
-  $ext = $mime_class->getExtension($object['OBJ']->mimeType);
-  $file_name = str_replace(':', '-', $object->id);
-  $original_file = file_save_data($object['OBJ']->content, 'temporary://' . $file_name . 'OBJ.' . $ext);
-  $tn_file = file_copy($original_file, 'temporary://' . $file_name . 'TN.' . $ext);
+
+  $original_file = $files["OBJ"];
+  $info = pathinfo($original_file);
+  $ext = $info["extension"];
+  $file_name = $info["filename"];
+
+  $tn_file = file_unmanaged_copy($original_file, 'temporary://' . $file_name . 'TN.' . $ext);
+  $_SESSION["fedora_ingest_files"]["TN"] = $tn_file;
   if (islandora_basic_image_create_derivative($tn_file, 200, 200)) {
-    islandora_basic_image_add_datastream($object, 'TN', $tn_file);
+    $files["TN"] = $tn_file;
   }
-  $medium_file = file_copy($original_file, 'temporary://' . $file_name . 'MEDIUM.' . $ext);
+
+  $medium_file = file_unmanaged_copy($original_file, 'temporary://' . $file_name . 'MEDIUM.' . $ext);
+  $_SESSION["fedora_ingest_files"]["MEDIUM_SIZE"] = $medium_file;
   if (islandora_basic_image_create_derivative($medium_file, 500, 700)) {
-    islandora_basic_image_add_datastream($object, 'MEDIUM_SIZE', $medium_file);
+    $files["MEDIUM_SIZE"] = $medium_file;
   }
-  file_delete($original_file);
+
+  return $files;
 }
 
 
@@ -41,7 +47,7 @@ function islandora_basic_image_create_all_derivatives($object) {
  *   stdclass
  */
 function islandora_basic_image_create_derivative($file, $width, $height) {
-  $real_path = drupal_realpath($file->uri);
+  $real_path = drupal_realpath($file);
   $image = image_load($real_path);
   if (!empty($image)) {
     $scale = image_scale($image, $width, $height, TRUE);
@@ -51,23 +57,3 @@ function islandora_basic_image_create_derivative($file, $width, $height) {
   }
   return FALSE;
 }
-
-/**
- * adds a datastream and deletes the tmp file from local file system
- * @param object $object
- * @param string $dsid
- * @param object $file 
- */
-function islandora_basic_image_add_datastream($object, $dsid, $file) {
-  try {
-    $ds = $object->constructDatastream($dsid, 'M');
-    $ds->label = $dsid;
-    $ds->mimeType = $object['OBJ']->mimeType;
-    $ds->setContentFromFile(drupal_realpath($file->uri));
-    $object->ingestDatastream($ds);
-    file_delete($file);
-  } catch (exception $e) {
-    drupal_set_message(t('@message', array('@message' => check_plain($e->getMessage()))), 'error');
-  }
-}
-

--- a/islandora_basic_image.module
+++ b/islandora_basic_image.module
@@ -171,21 +171,28 @@ function islandora_basic_image_islandora_view_object($object, $user, $page_numbe
   return NULL;
 }
 
+/**
+ * Creates derivative images prior to file ingestion, modifying $ingest_file_locations to add new
+ * datastreams-to-be
+ */
+function islandora_basic_image_islandora_before_content_model_form_ingest_files($ingest_file_locations, $object) {
+  module_load_include('inc', 'islandora_basic_image', 'includes/image.process');
+  return islandora_basic_image_create_all_derivatives($ingest_file_locations, $object);
+}
+
+/**
+ * Cleans up the temp file mess left behind from derivative images
+ */
 function islandora_basic_image_islandora_ingest_post_ingest($object) {
-  $cmodel_list = islandora_basic_image_islandora_get_types();
-  if(!isset($cmodel_list)){
-    return ;
+  if (!array_key_exists("fedora_ingest_files", $_SESSION)) {
+    return;
   }
-  $models = $object->models;
-  if(!isset($models)){
-    return ;
+
+  foreach ($_SESSION["fedora_ingest_files"] as $dsid => $file) {
+    file_unmanaged_delete($file);
   }
-  foreach ($models as $model) {
-    if (isset($cmodel_list[$model])) {
-      module_load_include('inc', 'islandora_basic_image', 'includes/image.process');
-      islandora_basic_image_create_all_derivatives($object);
-    }
-  }
+
+  unset($_SESSION["fedora_ingest_files"]);
 }
 
 /**


### PR DESCRIPTION
- Builds derivatives from pre-file-ingest hook
- Removes code used to pull image file out of fedora object since the
  raw upload is now available
- Removes islandora_basic_image_add_datastream since images are simply
  added to file-to-ingest array
- Uses SESSION and post-ingest hook to remove files copied in image
  derivative creation
