### PR TITLE
Order of operations for Islandora Batch...

### DIFF
--- a/xml/islandora_basic_image_ds_composite_model.xml
+++ b/xml/islandora_basic_image_ds_composite_model.xml
@@ -16,6 +16,11 @@
   <dsTypeModel ID="TECHMD" optional="true">
     <form MIME="application/xml"/>
   </dsTypeModel>
+  <dsTypeModel ID="OBJ">
+    <form MIME="image/jpeg"/>
+    <form MIME="image/png"/>
+    <form MIME="image/gif"/>
+  </dsTypeModel>
   <dsTypeModel ID="TN" ORDERED="false" optional="true">
     <form MIME="image/jpeg"/>
     <form MIME="image/png"/>
@@ -23,10 +28,5 @@
   </dsTypeModel>
   <dsTypeModel ID="MEDIUM_SIZE" ORDERED="false" optional="true">
     <form MIME="image/jpg"/>
-  </dsTypeModel>
-  <dsTypeModel ID="OBJ">
-    <form MIME="image/jpeg"/>
-    <form MIME="image/png"/>
-    <form MIME="image/gif"/>
   </dsTypeModel>
 </dsCompositeModel>


### PR DESCRIPTION
If you do a batch ingest with Islandora Batch, the jpg files will go to the TN datastream instead of the OBJ datastream. This resolves it.
